### PR TITLE
Update specs following `common-metadata` changes.

### DIFF
--- a/ip-intelligence-specification/data-model.md
+++ b/ip-intelligence-specification/data-model.md
@@ -16,7 +16,7 @@ as defined in the Pipeline specification.
 Element data returned by an IP Intelligence Engine MUST extend
 `IAspectData`.
 
-Each property MUST also be exposed as a [weighted value](../pipeline-specification/features/weighted-values.md) 
+Each property MUST also be exposed as a [weighted value](../pipeline-specification/features/weighted-values.md)
 
 ### Properties
 
@@ -49,7 +49,7 @@ interface IIpIntelligenceData
 ## WKT Type
 
 A new property type for the IP Intelligence Engine is the `WktString` interface.
-This uses a WKT/WKB shape (see https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry).
+This uses a WKT/WKB shape (see <https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry>).
 
 This comes from the data file in WKB format. And is interpreted to a more useable
 form, as the interface `WktString` which extends string, and contains a WKT
@@ -66,7 +66,7 @@ an [Aspect Property value](../pipeline-specification/features/properties.md#null
 in order to support exposing the reason that a value is not set.
 
 Additionally, values MUST be returned along with their weights when fetched
-from the `IAspectData`. Meaning the introduction of the 
+from the `IAspectData`. Meaning the introduction of the
 `IWeightedValue<T>` type, with the following properties:
 
 | Property | Type |
@@ -75,6 +75,7 @@ from the `IAspectData`. Meaning the introduction of the
 | Weighting | `float` |
 
 For example:
+
 ```{cs}
 // All weighted values for a property
 IAspectPropertyValue<IWeightedValue<int>> allValues = flowData
@@ -94,6 +95,7 @@ Data files follow the standard 51Degrees data file structure, with the addition
 of profile groups. See [Hash dataset](https://github.com/51Degrees/device-detection-cxx/blob/main/src/hash/hash.h#L295). Meaning that collections and headers are common,
 and logic from [common-cxx](https://github.com/51Degrees/common-cxx) should be used.
 Collections shared with Hash are:
+
 - values (named strings in Hash as only string values are used)
 - properties
 - profiles
@@ -103,7 +105,7 @@ See [general data model](../data-model-specification/README.md) for more info.
 
 ### Profile Groups
 
-A profile is pointed to by an integer offset. This is the same as existing data 
+A profile is pointed to by an integer offset. This is the same as existing data
 files. In the case where this offset is negative, it points to a group of
 profiles instead. Profile groups exist in a separate collection, and a profile
 group structure is an array of `WeightedProfile`, where `WeightedProfile` is:

--- a/ip-intelligence-specification/data-model.md
+++ b/ip-intelligence-specification/data-model.md
@@ -136,21 +136,5 @@ This does not mean that the properties are not exposed in the same way.
 
 The results contained in the combined result consists of the following 2 types:
 
-#### Network
-
-| Property | Type |
-| -------- | ---- |
-| IpRangeStart | `string` |
-| IpRangeEnd | `string` |
-| Name | `string` |
-| Owner | `string` |
-| Asn | `int` |
-
-#### Location
-
-| Property | Type |
-| -------- | ---- |
-| Latitude | `float` |
-| Longitude | `float` |
-| Areas | `WktString` |
-| AccuracyRadius | `int` |
+- [Network](https://github.com/51Degrees/common-metadata/tree/main/Properties/Network)
+- [Location](https://github.com/51Degrees/common-metadata/tree/main/Properties/Location)

--- a/pipeline-specification/features/weighted-values.md
+++ b/pipeline-specification/features/weighted-values.md
@@ -14,18 +14,21 @@ Given an example `IElementData` implementation `IExampleData` which contains a p
 `ExampleProperty`
 
 1. Get the value in the standard way described in [access-to-results](./access-to-results.md):
+
 ```c#
 IExampleData data;
 IReadOnlyList<IWeightedValue<string>> values = data.ExampleProperty;
 ```
 
 2. Fetch the most likely value. The values are ordered from highest to lowest probability:
+
 ```c#
 IReadOnlyList<IWeightedValue<string>> values;
 string mostLikelyValue = values[0].Value;
 ```
 
 3. Get the probabilities of each value:
+
 ```c#
 IReadOnlyList<IWeightedValue<string>> values;
 foreach (var weightedValue in values)
@@ -35,9 +38,10 @@ foreach (var weightedValue in values)
 }
 ```
 
-## Serializing 
+## Serializing
 
 When serializing weighted values, they are represented like:
+
 ```js
 {
     "WeightedPropertyName": [

--- a/pipeline-specification/features/weighted-values.md
+++ b/pipeline-specification/features/weighted-values.md
@@ -33,7 +33,7 @@ string mostLikelyValue = values[0].Value;
 IReadOnlyList<IWeightedValue<string>> values;
 foreach (var weightedValue in values)
 {
-    float weighting = weightedValue.Weighting;
+    float weighting = weightedValue.Weighting();
     string value = weightedValue.Value;
 }
 ```
@@ -45,8 +45,14 @@ When serializing weighted values, they are represented like:
 ```js
 {
     "WeightedPropertyName": [
-        { "Weighting": 0.9, "Value": "value 1" },
-        { "Weighting": 0.1, "Value": "value 2" }
+        { "RawWeighting": 32768, "Value": "value 1" },
+        { "RawWeighting": 32767, "Value": "value 2" }
     ]
 }
 ```
+
+The raw weighting is stored as a 16-bit unsigned integer (aka [ushort](https://learn.microsoft.com/en-us/dotnet/api/system.uint16.maxvalue?view=netstandard-2.0)).
+
+The sum of raw weightings for all values within any specific property should always add up to [UInt16.MaxValue](https://learn.microsoft.com/en-us/dotnet/api/system.uint16.maxvalue?view=netstandard-2.0) (that represents a `1.0` "likelyhood").
+
+See [IWeightedValue.cs](https://github.com/51Degrees/pipeline-dotnet/blob/version/4.5/FiftyOne.Pipeline.Core/Data/IWeightedValue.cs) for more details.


### PR DESCRIPTION
### Changes

- Explain `ushort` serialization for `WeightedValue`.
- Point to `common-metadata` instead of having inline components table.

### Related

- https://github.com/51Degrees/common-metadata/pull/20