### PR TITLE
Reverse lazy start-up discovery for the Cloud Request Engine

### DIFF
--- a/pipeline-specification/pipeline-elements/cloud-aspect-engine.md
+++ b/pipeline-specification/pipeline-elements/cloud-aspect-engine.md
@@ -37,7 +37,18 @@ the Pipeline.
 Each Cloud Aspect Engine accesses that data to obtain Property metadata relating 
 to the Properties that it populates.
 
-The Cloud Request Engine resolves this information when it is [built](cloud-request-engine.md#start-up-activity), so a Cloud Aspect Engine built after it can read the accessible Properties and populate its Property metadata at build time. If the Cloud Request Engine cannot be built (for example because the cloud is unavailable), that failure surfaces when the Pipeline is built rather than on first use, so a built Cloud Aspect Engine always has its metadata.
+The Cloud Request Engine normally resolves this information when it is
+[built](cloud-request-engine.md#start-up-activity), so a Cloud Aspect Engine
+built after it can read the accessible Properties and populate its Property
+metadata at build time. A definitive configuration error (such as an invalid
+Resource Key) fails the Pipeline build rather than surfacing on first use.
+
+However, after a transient failure (for example the cloud temporarily
+unreachable at build time) the Cloud Request Engine still builds and retries
+discovery on first use. A Cloud Aspect Engine therefore MUST treat the Property
+metadata as failable, lazily-completed data: it MUST tolerate the metadata
+being temporarily absent and MUST NOT permanently cache an empty result
+obtained before the Cloud Request Engine's discovery has completed.
 
 ## Processing
 

--- a/pipeline-specification/pipeline-elements/cloud-aspect-engine.md
+++ b/pipeline-specification/pipeline-elements/cloud-aspect-engine.md
@@ -37,15 +37,7 @@ the Pipeline.
 Each Cloud Aspect Engine accesses that data to obtain Property metadata relating 
 to the Properties that it populates.
 
-The Cloud Request Engine does not [request](cloud-request-engine.md#start-up-activity)
-this information on start-up, but instead treats it as lazily initialized data - that 
-MUST be initialized only close to the time of first use.  In case it fails to initialize
-and the exceptions are suppressed - then the attempt will be made to do so on subsequent call
-to get these properties.  
-
-Cloud Aspect Engine thus MUST NOT cache the Property metadata and instead SHOULD always 
-treat it as lazily initialized failable data.  This is due to a [re-designed
-start-up behavior](cloud-request-engine.md#updated-design) of Cloud Request Engine.
+The Cloud Request Engine resolves this information when it is [built](cloud-request-engine.md#start-up-activity), so a Cloud Aspect Engine built after it can read the accessible Properties and populate its Property metadata at build time. If the Cloud Request Engine cannot be built (for example because the cloud is unavailable), that failure surfaces when the Pipeline is built rather than on first use, so a built Cloud Aspect Engine always has its metadata.
 
 ## Processing
 

--- a/pipeline-specification/pipeline-elements/cloud-request-engine.md
+++ b/pipeline-specification/pipeline-elements/cloud-request-engine.md
@@ -49,8 +49,9 @@ for more information.
 
 Accepted Evidence is dependent on the supplied Resource Key.
 
-The Engine will make a request to its remote server to get this information.  This should be
-treated as data that the Engine resolves when it is built, see the [start-up activity](#start-up-activity).
+The Engine will make a request to its remote server to get this information.  The Engine
+resolves it when it is built, retrying on first use only after a transient failure, see the
+[start-up activity](#start-up-activity).
 
 ## Element Data
 
@@ -91,17 +92,18 @@ An example of the JSON response received from the server:
 ## Start-up activity
 
 There were design issues with a previous revision of this specification, and the
-design of start-up activity has been corrected. The implementation should follow
-the corrected design below for all APIs. The withdrawn "lazy" design and the
+design of start-up activity has been revised. The implementation should follow
+the revised design below for all APIs. The withdrawn fully lazy design and the
 reasons it was wrong are kept at the end for context.
 
-### Corrected design (discovery at build time)
+### Revised design (eager discovery at build time, transient-failure fallback)
 
 On start-up the Engine resolves, for the configured Resource Key, the accessible
 Properties (from the [configured](#configuration-options) `accessibleproperties`
-endpoint) and the accepted Evidence keys (from `evidencekeys`). This happens when
-the Engine is built (in its builder or constructor), not lazily on first use, so
-a built Engine is fully initialised and immediately ready to process Flow Data.
+endpoint) and the accepted Evidence keys (from `evidencekeys`). The Engine MUST
+attempt both discovery requests when it is built (in its builder or constructor),
+and MAY make them in parallel, so that in the normal case a built Engine is fully
+initialised and immediately ready to process Flow Data.
 
 The result from `accessibleproperties` populates a publicly accessible (read
 only) collection describing the data and Properties expected from the cloud
@@ -109,41 +111,66 @@ service for this Resource Key. [Cloud Aspect Engines](cloud-aspect-engine.md) us
 it to populate their Property metadata collections. The result from `evidencekeys`
 populates the [accepted Evidence](#accepted-evidence) for the Engine.
 
-If either request fails, building the Engine MUST fail with a critical error, as
-the Pipeline cannot function correctly without this information. See
-[HTTP requests](#http-requests) for general details on HTTP request handling.
+How a discovery failure at build time is handled depends on its class:
 
-### Resilience without lazy loading
+- **Definitive configuration errors** - an HTTP 4xx response to a discovery
+  request (for example an invalid Resource Key) - MUST fail the build with a
+  critical error. Retrying with the same configuration can never succeed, so
+  the Engine fails fast with a clear error at start-up instead of surfacing the
+  misconfiguration on the first request.
+- **Transient failures** - the service unreachable (DNS or connection failure),
+  a timeout, or an HTTP 5xx response - MUST NOT fail the build. The Engine MUST
+  log a warning, complete the build, and retry discovery on first use. Failures
+  of those first-use retries are process-time failures, so
+  [`SuppressProcessExceptions`](../features/exception-handling.md) applies to
+  them as to any other processing error.
+
+A temporary cloud outage at construction time therefore cannot prevent the
+application from starting, while a misconfiguration surfaces immediately.
+
+See [HTTP requests](#http-requests) for general details on HTTP request handling.
+
+### Consequences for consumers of the Engine
+
+When discovery succeeds at build time (the normal case), consumers that read the
+Engine while the Pipeline is assembled - the pipeline-wide accepted-Evidence
+filter (used for the web `Vary` header), the SetHeaders element (client-hints
+`Accept-CH`), and Property-metadata introspection - see correct, complete data
+before the first request.
+
+After a transient discovery failure, the built Engine advertises empty accepted
+Evidence and empty Property metadata until a first-use retry succeeds. Consumers
+of this information therefore MUST tolerate it being temporarily absent and MUST
+NOT permanently cache an empty result obtained before discovery has completed.
+
+### Resilience
 
 The concern that originally motivated lazy loading (an outage of the 51Degrees
-cloud must not bring the customer service down) is met without deferring
-discovery.
+cloud must not bring the customer service down) is met by the transient-failure
+fallback above rather than by deferring all discovery.
 
-- Building the Engine surfaces a discovery failure as an ordinary, catchable
-  error (a returned error, or an exception that the integration constructs the
-  Pipeline inside and can handle). The application controls when construction
-  happens, so it can retry, back off or degrade. This differs from the situation
-  lazy loading worried about, where construction happened implicitly in a place
-  that could not catch the error.
-- Implementations SHOULD allow an Engine to be built from a previously obtained,
-  persisted copy of the discovery results (the accepted Evidence keys and the
-  accessible Properties, which depend only on the Resource Key). When supplied,
-  the builder uses it and makes no cloud request, so the Pipeline can be built
-  offline and a short-lived or frequently-restarted host (for example a serverless
-  or edge / WebAssembly runtime) need not call the cloud on every cold start. The
-  persisted copy is read back from the builder after a successful build.
+In addition, implementations SHOULD allow an Engine to be built from a
+previously obtained, persisted copy of the discovery results (the accepted
+Evidence keys and the accessible Properties, which depend only on the Resource
+Key). When supplied, the builder uses it and makes no cloud request, so the
+Pipeline can be built offline and a short-lived or frequently-restarted host
+(for example a serverless or edge / WebAssembly runtime) need not call the
+cloud on every cold start. The persisted copy is read back from the builder
+after a successful build. At the time of writing no implementation provides
+this yet.
 
-### Why the lazy design was withdrawn
+### Why the fully lazy design was withdrawn
 
 A previous revision deferred the `accessibleproperties` and `evidencekeys`
-requests to the first `Process` call ("lazy" discovery), so that a
-[`SuppressProcessExceptions`](../features/exception-handling.md) Pipeline could
-absorb a cloud outage at start-up rather than failing construction.
+requests to the first `Process` call ("lazy" discovery) unconditionally, so
+that a [`SuppressProcessExceptions`](../features/exception-handling.md)
+Pipeline could absorb a cloud outage at start-up rather than failing
+construction.
 
-That design has been withdrawn. It was a mistake, because it left a "built" Engine
-that was not actually ready to process Flow Data.
+That design has been withdrawn, because it left a "built" Engine that was not
+ready to process Flow Data even when the cloud was perfectly healthy:
 
-- Construction no longer meant ready. A built Engine reported an empty
+- Construction did not mean ready. A built Engine reported an empty
   accepted-Evidence filter and empty Property metadata until its first `Process`,
   which is a broken abstraction.
 - Consumers that read the Engine when the Pipeline is assembled, before any
@@ -153,14 +180,21 @@ that was not actually ready to process Flow Data.
   features such as the client-hints `Accept-CH` headers did not work on the first
   request.
 - Metadata introspection before the first `Process` returned wrong, empty answers.
+- It hid configuration errors: an invalid Resource Key only surfaced on the
+  first request, in whatever context happened to trigger it, instead of at
+  start-up.
+
+The revised design keeps first-use retry only as the fallback path for
+transient outages; it is no longer the normal start-up behaviour.
 
 ### Impact on implementations
 
-Every SDK that adopted the withdrawn lazy design MUST move the `accessibleproperties`
-and `evidencekeys` requests back to Engine construction and remove the first-use
-deferral, so that a built Engine is ready to process. This is a small, localised
-change to the Cloud Request Engine. Adding the optional persisted-state constructor
-described above is recommended so the resilience properties are retained.
+Every SDK that adopted the withdrawn lazy design MUST warm discovery at Engine
+construction as described above: attempt both requests at build time, fail the
+build on a definitive configuration error, and fall back to first-use retry
+only after a transient failure. This is a small, localised change to the Cloud
+Request Engine. Adding the optional persisted-state constructor described
+above is recommended so a Pipeline can also be built entirely offline.
 
 ## Processing
 

--- a/pipeline-specification/pipeline-elements/cloud-request-engine.md
+++ b/pipeline-specification/pipeline-elements/cloud-request-engine.md
@@ -50,7 +50,7 @@ for more information.
 Accepted Evidence is dependent on the supplied Resource Key.
 
 The Engine will make a request to its remote server to get this information.  This should be
-treated is failable lazy loaded data, see the [redesigned start-up activity](#updated-design).
+treated as data that the Engine resolves when it is built, see the [start-up activity](#start-up-activity).
 
 ## Element Data
 
@@ -90,59 +90,77 @@ An example of the JSON response received from the server:
 
 ## Start-up activity
 
-There were design issues discovered and the design of start-up activity has been updated.
-The implementation should follow the updated design for all APIs.  For historical purposes the previous design
-is left as is below, and then changes explanations follow.
+There were design issues with a previous revision of this specification, and the
+design of start-up activity has been corrected. The implementation should follow
+the corrected design below for all APIs. The withdrawn "lazy" design and the
+reasons it was wrong are kept at the end for context.
 
-### Previous Design
+### Corrected design (discovery at build time)
 
-On start-up, the Engine will call its [configured](#configuration-options)
-`accessibleproperties` and `evidencekeys` endpoints, using the configured Resource Key.
+On start-up the Engine resolves, for the configured Resource Key, the accessible
+Properties (from the [configured](#configuration-options) `accessibleproperties`
+endpoint) and the accepted Evidence keys (from `evidencekeys`). This happens when
+the Engine is built (in its builder or constructor), not lazily on first use, so
+a built Engine is fully initialised and immediately ready to process Flow Data.
 
-The result from `accessibleproperties` will be used to populate a publicly
-accessible (read only) dictionary containing details of the data and
-Properties that are expected to be returned by the cloud service for this
-Resource Key.
+The result from `accessibleproperties` populates a publicly accessible (read
+only) collection describing the data and Properties expected from the cloud
+service for this Resource Key. [Cloud Aspect Engines](cloud-aspect-engine.md) use
+it to populate their Property metadata collections. The result from `evidencekeys`
+populates the [accepted Evidence](#accepted-evidence) for the Engine.
 
-This information will then be used by [Cloud Aspect Engines](cloud-aspect-engine.md)
-to populate their Property metadata collections.
+If either request fails, building the Engine MUST fail with a critical error, as
+the Pipeline cannot function correctly without this information. See
+[HTTP requests](#http-requests) for general details on HTTP request handling.
 
-The result from `evidencekeys` will be used to populate the
-[accepted Evidence](#accepted-evidence) for this Engine.
+### Resilience without lazy loading
 
-If either of these requests fails, the Engine MUST throw a critical
-error as the Pipeline will be unable to function correctly.
+The concern that originally motivated lazy loading (an outage of the 51Degrees
+cloud must not bring the customer service down) is met without deferring
+discovery.
 
-See [HTTP requests](#http-requests) for general details on
-HTTP request handling.
+- Building the Engine surfaces a discovery failure as an ordinary, catchable
+  error (a returned error, or an exception that the integration constructs the
+  Pipeline inside and can handle). The application controls when construction
+  happens, so it can retry, back off or degrade. This differs from the situation
+  lazy loading worried about, where construction happened implicitly in a place
+  that could not catch the error.
+- Implementations SHOULD allow an Engine to be built from a previously obtained,
+  persisted copy of the discovery results (the accepted Evidence keys and the
+  accessible Properties, which depend only on the Resource Key). When supplied,
+  the builder uses it and makes no cloud request, so the Pipeline can be built
+  offline and a short-lived or frequently-restarted host (for example a serverless
+  or edge / WebAssembly runtime) need not call the cloud on every cold start. The
+  persisted copy is read back from the builder after a successful build.
 
-### Updated Design
+### Why the lazy design was withdrawn
 
-#### Motivation for change
+A previous revision deferred the `accessibleproperties` and `evidencekeys`
+requests to the first `Process` call ("lazy" discovery), so that a
+[`SuppressProcessExceptions`](../features/exception-handling.md) Pipeline could
+absorb a cloud outage at start-up rather than failing construction.
 
-There was a problem with the old design.
+That design has been withdrawn. It was a mistake, because it left a "built" Engine
+that was not actually ready to process Flow Data.
 
-We have discovered that customers encounter severe problems in case 51d cloud service, server machine or domain (cloud.51degrees.com)
-are down or unavailable.  In this case the `CloudRequestEngine`  constructor would not be able to obtain `eviddencekeys` or `accessibleproperties`
-and would throw an exception.  This can bring the whole customer service down especially in the [web integrations](../features/web-integration.md) where Pipeline functions as part of a request processing module/plugin (f.e. .NET Cloud/Framework-Web integration) - and the integration code does not even have an opportunity to properly catch the exceptions.
+- Construction no longer meant ready. A built Engine reported an empty
+  accepted-Evidence filter and empty Property metadata until its first `Process`,
+  which is a broken abstraction.
+- Consumers that read the Engine when the Pipeline is assembled, before any
+  `Process`, saw nothing. The pipeline-wide accepted-Evidence filter (used for the
+  web `Vary` header) and the SetHeaders element read the Engine's advertised keys
+  and Properties at Pipeline-build time, so under lazy loading they were empty, and
+  features such as the client-hints `Accept-CH` headers did not work on the first
+  request.
+- Metadata introspection before the first `Process` returned wrong, empty answers.
 
-Of course construction should happen once, but there are service restarts and/or starts that might occur f.e. due to auto-scaling - so construction can happen undeterministically and
-the customer can end up with an unitializable pipeline under the above circumstance.
+### Impact on implementations
 
-However there is already a feature [`SuppressProcessExceptions`](../features/exception-handling.md) - this is a configuration flag that tells Pipeline
-to not throw exceptions during processing.  We wanted to use this flag and extend its effect on this scenario when `evidencekeys` or `accessibleproperties` can
-not be obtained due to host being down or due to other reasons.  
-
-### Changes
-
-The above motivation led to the following design decision.  `evidencekeys`, `accessibleproperties` or any future dependence on cloud.51degrees.com
-(or any other external service) - must be made **lazy** and obtained (once and then cached) only at the point of first use!  In particular they must be made initialized
-within the scope of a (Web)Pipeline.Process method call.  
-
-That way if the host is down and any exception is thrown - the `SuppressProcessExceptions`, if it was specified
-in the Pipeline configuration, would take effect and the exceptions would be suppressed and logged rather than throwing and bringing the customer service down.
-**Thus, there is no particular start up activity, but any "start-up" properties should be made lazy for this element.**
-Throwing exceptions if either of these lazy properties fails to initialize still holds, however they now will be thrown in the context of Process() and not constructor.  
+Every SDK that adopted the withdrawn lazy design MUST move the `accessibleproperties`
+and `evidencekeys` requests back to Engine construction and remove the first-use
+deferral, so that a built Engine is ready to process. This is a small, localised
+change to the Cloud Request Engine. Adding the optional persisted-state constructor
+described above is recommended so the resilience properties are retained.
 
 ## Processing
 


### PR DESCRIPTION
## Summary

Reverse the "lazy" start-up design for the Cloud Request Engine. Discovery of the accepted evidence keys (`evidencekeys`) and accessible properties (`accessibleproperties`) now happens when the engine is **built**, not deferred to the first `Process`. A built engine is therefore ready to process flow data immediately.

## Why this is needed

The lazy design was a mistake: a "built" engine was not actually ready to process. Until its first `Process`, the engine advertised an **empty** accepted-evidence filter and **empty** property metadata. That breaks every consumer that reads the engine when the pipeline is assembled, before any request:

- the pipeline-wide accepted-evidence filter used for the web `Vary` header,
- the SetHeaders element, so the client-hints `Accept-CH` headers did not work on the first request,
- any property-metadata introspection performed before processing.

"Built but not ready" is a broken abstraction that surprises both callers and downstream elements.

## Resilience, the original motivation

Lazy loading was introduced so that an outage of the 51Degrees cloud at start-up could be absorbed by `SuppressProcessExceptions` rather than failing construction. That concern is met without deferring discovery:

- Building the engine surfaces a discovery failure as an ordinary, catchable error. The application controls when construction happens, so it can retry, back off or degrade. This is unlike the situation lazy loading worried about, where construction happened implicitly somewhere the error could not be caught.
- Implementations SHOULD allow an engine to be built from a previously obtained, persisted copy of the discovery results (they depend only on the resource key). The pipeline can then be built offline, and a short-lived or frequently restarted host (serverless, edge or WebAssembly) need not call the cloud on every cold start.

## Impact on implementations

Every SDK that adopted the lazy design MUST move the two requests back to construction and remove the first-use deferral, so a built engine is ready to process. This is a small, localised change to the Cloud Request Engine. Adding the optional persisted-state constructor is recommended so the resilience properties are retained.

## Files

- `pipeline-specification/pipeline-elements/cloud-request-engine.md`: start-up section rewritten (corrected design, resilience, why the lazy design was withdrawn, impact on implementations).
- `pipeline-specification/pipeline-elements/cloud-aspect-engine.md`: start-up text updated to match.

Raised as a draft for review with engineering.
